### PR TITLE
Tweaks to Kubernetes_all_in_one.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*~
+Kubernetes_all_in_one/ubuntu-xenial-16.04-cloudimg-console.log
+Kubernetes_all_in_one/.vagrant

--- a/Kubernetes_all_in_one/README.md
+++ b/Kubernetes_all_in_one/README.md
@@ -1,0 +1,3 @@
+# Kubernetes_all_in_one support files
+
+Vagrantfile used to try out the steps documented in Kubernetes_all_in_one.md

--- a/Kubernetes_all_in_one/Vagrantfile
+++ b/Kubernetes_all_in_one/Vagrantfile
@@ -1,0 +1,31 @@
+require 'yaml'
+
+vagrant_config = YAML.load_file("vagrant.conf.yml")
+
+$apt_upgrade = <<SCRIPT
+  apt-get update && \
+  apt-get -y upgrade && \
+  echo "apt upgraded"
+SCRIPT
+
+Vagrant.configure(2) do |config|
+  config.vm.box_check_update = false
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'" # avoids 'stdin: is not a tty' error.
+
+  config.vm.define "ubuntu", primary: true, autostart: vagrant_config['ubuntu']['autostart'] do |ubuntu|
+    ubuntu.vm.box = vagrant_config['ubuntu']['box']
+    ubuntu.vm.hostname = vagrant_config['ubuntu']['host_name']
+    ## ubuntu.vm.network "private_network", ip: vagrant_config['ubuntu']['secondary_ip'], virtualbox__intnet: "vboxnet0", auto_config: true
+    ubuntu.vm.network "private_network", ip: vagrant_config['ubuntu']['secondary_ip'], auto_config: true
+
+    ubuntu.vm.provider :virtualbox do |vb|
+      # vb.gui = true
+      vb.memory = vagrant_config['ubuntu']['memory']
+      vb.cpus = vagrant_config['ubuntu']['cpus']
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+    end
+
+    ubuntu.vm.provision "apt_upgrade", type: "shell", inline: $apt_upgrade
+  end
+end
+

--- a/Kubernetes_all_in_one/vagrant.conf.yml
+++ b/Kubernetes_all_in_one/vagrant.conf.yml
@@ -1,0 +1,8 @@
+---
+ubuntu:
+  box: "ubuntu/xenial64"
+  autostart: true
+  host_name: "babykube"
+  memory: 4096
+  cpus: 2
+  secondary_ip: 192.168.99.134


### PR DESCRIPTION
Minor changes to make it easier to cut-and-paste.

Created a Vagrantfile to make it convenient to stamp out VM for trying it out

Follow up questions:
1) why is this better than just doing a "minikube start --vm-driver=none"  ?
2) I'm still a little confused about the usage of babykube vs. babykube1
3) do we really need to be root for all the commands?